### PR TITLE
Ádd gcloud library. Add gcloud authentication provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "action-executor",
+    "gcloud",
     "trigger-interpreter",
     "trigger-system",
     "trigger-svc",

--- a/gcloud/Cargo.toml
+++ b/gcloud/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gcloud"
+version = "0.1.0"
+authors = ["William Dussault <dalloriam@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dev-dependencies]
+tempfile = "3"
+
+[dependencies]
+base64 = "0.12"
+google-datastore1 = "*"
+google-pubsub1 = "*"
+hyper = "^0.10"
+hyper-rustls = "^0.6"
+serde = "^1.0"
+serde_json = "^1.0"
+snafu = "0.6"
+yup-oauth2 = "^1.0"

--- a/gcloud/src/auth.rs
+++ b/gcloud/src/auth.rs
@@ -1,0 +1,98 @@
+use std::error::Error;
+use std::io;
+use std::path::Path;
+
+use hyper::Client;
+
+use snafu::{ResultExt, Snafu};
+
+use yup_oauth2::{GetToken, ServiceAccountAccess, Token};
+
+use crate::https;
+
+/// Possible auth errors.
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)] // Otherwise, cargo will ask to document each field of each error, which is a bit overkill.
+pub enum AuthError {
+    /// Error returned when the service account key file couldn't be read
+    /// by the authentication provider.
+    #[snafu(display("Failed to read service account key: {}", source))]
+    FailedToReadServiceAccountKey { source: io::Error },
+}
+
+type Result<T> = std::result::Result<T, AuthError>;
+
+/// Provides google cloud authentication with a simple API.
+///
+/// It requires less boilerplate than the bare `yup_oauth2` provider, and it implements
+/// the `oauth::GetToken` trait, which means it can be used directly with Pubsub & Datastore clients.
+pub struct AuthProvider {
+    access_manager: ServiceAccountAccess<Client>,
+}
+
+impl AuthProvider {
+    /// Create an auth provider from a JSON file on disk.
+    ///
+    /// # Errors
+    /// Returns an AuthError if the file cannot be read or if it doesn't contain
+    /// valid JSON.
+    pub fn from_json_file<P: AsRef<Path>>(path: &P) -> Result<AuthProvider> {
+        // This is needed because `yup_oauth2` doesn't support `std::Path`...
+        let path_str = String::from(path.as_ref().to_string_lossy());
+
+        let secret = yup_oauth2::service_account_key_from_file(&path_str)
+            .context(FailedToReadServiceAccountKey)?;
+
+        let access_manager = ServiceAccountAccess::new(secret, https::new_tls_client());
+
+        Ok(AuthProvider { access_manager })
+    }
+}
+
+impl GetToken for AuthProvider {
+    fn token<'b, I, T>(&mut self, scopes: I) -> std::result::Result<Token, Box<dyn Error>>
+    where
+        T: AsRef<str> + Ord + 'b,
+        I: IntoIterator<Item = &'b T>,
+    {
+        self.access_manager.token(scopes)
+    }
+
+    fn api_key(&mut self) -> Option<String> {
+        self.access_manager.api_key()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use tempfile::NamedTempFile;
+
+    use super::AuthProvider;
+
+    #[test]
+    fn provider_from_json_file_exists() {
+        let mut temp_json_file = NamedTempFile::new().unwrap();
+        let auth_json = include_bytes!("test_data/valid_key.json");
+        temp_json_file.write_all(auth_json.as_ref()).unwrap();
+
+        // For now we only validate that the auth provider is created without errors.
+        let _provider = AuthProvider::from_json_file(&temp_json_file.path()).unwrap();
+    }
+
+    #[test]
+    fn provider_from_json_nonexistent_file() {
+        let mock_path = PathBuf::from("/some/bad/path");
+        assert!(AuthProvider::from_json_file(&mock_path).is_err());
+    }
+
+    #[test]
+    fn provider_from_json_bad_json() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(b"bing bong").unwrap();
+
+        assert!(AuthProvider::from_json_file(&temp_file.path()).is_err());
+    }
+}

--- a/gcloud/src/https.rs
+++ b/gcloud/src/https.rs
@@ -1,0 +1,23 @@
+use hyper::{net::HttpsConnector, Client};
+use hyper_rustls::TlsClient;
+
+/// Returns a preconfigured Hyper TLS client.
+///
+/// The client uses a hyper HttpsConnector with a `hyper_rustls` TLS Client.
+pub fn new_tls_client() -> Client {
+    let tls_client = TlsClient::new();
+    let https_connector = HttpsConnector::new(tls_client);
+    Client::with_connector(https_connector)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::new_tls_client;
+
+    #[test]
+    fn test_client_instantiation() {
+        // Not much to test..
+        // Let's validate that client instatiation doesn't panic at least..
+        let _client = new_tls_client();
+    }
+}

--- a/gcloud/src/lib.rs
+++ b/gcloud/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(missing_docs)] // Force documentation of all public interfaces.
+//! User-friendly GCloud wrappers.
+
+mod auth;
+mod https;
+
+pub use auth::{AuthError, AuthProvider};

--- a/gcloud/src/test_data/valid_key.json
+++ b/gcloud/src/test_data/valid_key.json
@@ -1,0 +1,12 @@
+{
+    "type": "service_account",
+    "project_id": "some-project",
+    "private_key_id": "d65eb4894b23b23d570aed5adaf26096d5bb0051",
+    "private_key": "-----BEGIN RSA PRIVATE KEY----- MIICWwIBAAKBgH+ei8J9gvIR2lUfc+3BPQC73yP9iEx2sDgHF6Vatll2ewqCQ5SO Dm7JRp52bqFehcUd08FFpCdGro8dfscDjEvfQbW5O1typBBBJeNGzDF+oVgBY80K AjNCPoSE2I6XMFTF1E7G6EiQjjBfnyy9nEp2Q9DHQNaA+/3I03nrszCjAgMBAAEC gYBu/U9lbc0FhHtTDtC/FRFd4wa1AVmZzpuBjsGE4Li4Y6+suw/VUhrBRTGyvSOI GnHSthck/tE+C13jP+6zXKWVSwZIvd+jzezMDVd6KKbqkK3xQ4H9BryKQ7P97iIr kTXb9TCLdRX6877UgFkOdjiyjlNXzXmLF0PcF1WQJNpDEQJBAPIMggdBJdlsgB4V DyBpYqo5RCk7riMXjC+9tmUDoH4O1jItb4aFcr2VVUZNtF5fQfS2dC/z7vCGStlF +Dhd5QsCQQCG+ZnrlUvtcoAI0doFC6VFolPb82yo1BwmctafIysRbjir4GVWPC55 LygTyo5zaKs2uGlrYZ3cN68II/2y8fHJAkEAqlMc6MfyP2Z3XTPKei9Oa6Ryj2Vc q3r1fd7My5ZayHneRl7snMepLzk3UYp6gvIbMn11kwzfNcf6QZxYCCoicwJAPtRz pOlTdc2l8fUVouGf5oFAvhNbUl+iVveAFoX9Z1jCgqerJHBRRdIAuu3AT9K6WHeR gw3muPsmvAhc8W6UmQJAV16KrBDoMPZ3yiKIyUVeAiRTDlgPFRGZhWiFcbrQTfbU gy9yV4Bo/NFkguxucaoWYAKF4eeD3tGio57wFY0koQ== -----END RSA PRIVATE KEY-----",
+    "client_email": "mock_app@appspot.gserviceaccount.com",
+    "client_id": "111104816727272291010106",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/mock_app%40appspot.gserviceaccount.com"
+}


### PR DESCRIPTION
Fixes #8 .

J'ai ajouté un AuthenticationProvider avec une lib GCloud & une couple de tests (t'inquiètes, la key que j'ai commit c'est un mock). 

Hésite pas à comment -- pas juste si tu vois des trucs sketch mais sur toutes les choses que tu comprends pas, design, etc.

Cheers 👍 